### PR TITLE
Make QR Dependency Optional

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -6,7 +6,7 @@
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.requests" version="2.18.4"/>
-    <import addon="script.module.qrcode" version="5.2"/> <!-- For QR Code display for Dropbox API authentication -->    
+    <import addon="script.module.qrcode" version="5.2" optional="true" /> <!-- For QR Code display for Dropbox API authentication -->    
   </requires>
   <extension point="xbmc.python.library" library="authenticate.py"> <!-- entry to start the authentification script from the settings dialog of other addons -->
     <provides> </provides> <!-- Addon should not be shown anywhere -->


### PR DESCRIPTION
The QR code dependency for authorization definitely makes things easier for some integrators, but not everyone will want to use this as part of their addon. Some, myself included, may simply want to use the dropbox lib and not have to rely on the additional dependency that isn't part of the core dropbox library. 

This will mark the [dependency as optional](https://kodi.wiki/view/Addon.xml#.3Cimport.3E), unless the addon in question is actually going to use it. 