### PR TITLE
Import Errors - missing files and dependencies 

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -6,6 +6,7 @@
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.requests" version="2.18.4"/>
+	<import addon="script.module.six" version="1.11.0" />
     <import addon="script.module.qrcode" version="5.2"/> <!-- For QR Code display for Dropbox API authentication -->    
   </requires>
   <extension point="xbmc.python.library" library="authenticate.py"> <!-- entry to start the authentification script from the settings dialog of other addons -->

--- a/lib/dropbox/pkg_resources.py
+++ b/lib/dropbox/pkg_resources.py
@@ -1,0 +1,3 @@
+
+def resource_filename(*args):
+    return "trusted-certs.crt"


### PR DESCRIPTION
In the [sessions.py](https://github.com/micahg/script.module.dropbox/blob/master/lib/dropbox/session.py#L1) file of the Dropbox library there is an import of "pkg_resources". Not sure if this happens on other platforms, but on Windows there is an error generated upon import of the dropbox addon. 

```
2019-08-19 09:42:55.901 T:9680   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.ImportError'>
                                            Error Contents: No module named pkg_resources
                                            Traceback (most recent call last):
                                              File "C:\Users\rweber\AppData\Roaming\Kodi\addons\script.xbmcbackup\scheduler.py", line 9, in <module>
                                                from resources.lib.backup import XbmcBackup
                                              File "C:\Users\rweber\AppData\Roaming\Kodi\addons\script.xbmcbackup\resources\lib\backup.py", line 8, in <module>
                                                from vfs import XBMCFileSystem,DropboxFileSystem,ZipFileSystem,GoogleDriveFilesystem
                                              File "C:\Users\rweber\AppData\Roaming\Kodi\addons\script.xbmcbackup\resources\lib\vfs.py", line 11, in <module>
                                                import dropbox
                                              File "C:\Users\rweber\AppData\Roaming\Kodi\addons\script.module.dropbox\lib\dropbox\__init__.py", line 3, in <module>
                                                from .dropbox import __version__, Dropbox, DropboxTeam, create_session  # noqa: F401
                                              File "C:\Users\rweber\AppData\Roaming\Kodi\addons\script.module.dropbox\lib\dropbox\dropbox.py", line 35, in <module>
                                                from .session import (
                                              File "C:\Users\rweber\AppData\Roaming\Kodi\addons\script.module.dropbox\lib\dropbox\session.py", line 1, in <module>
                                                import pkg_resources
                                            ImportError: No module named pkg_resources
                                            -->End of Python script error report<--
```

I'm working on using this module as part of the [Backup addon](https://github.com/robweber/xbmcbackup/issues/151) instead of duplicating the dropbox library within that addon as well. I noticed after seeing this error that I had included a dummy pkg_resources file to remove this error. This removes the error and allows the dropbox library to load and function as normal. 

__Note__ This was test on Windows using Kodi Leia 18.3